### PR TITLE
unicorn: Implement A/B partitioning for vm-bootsys.img

### DIFF
--- a/proprietary-firmware.txt
+++ b/proprietary-firmware.txt
@@ -18,7 +18,7 @@ shrm.img;AB
 tz.img;AB
 uefi.img;AB
 uefisecapp.img;AB
-vm-bootsys.img
+vm-bootsys.img;AB
 xbl.img;AB
 xbl_config.img;AB
 xbl_ramdump.img;AB


### PR DESCRIPTION
Hello, I'm having some problems with this and trying to fix it!
1.vm-bootsys.img should be an AB partition.
2. vendor/firmware/st_fts_l1.ftb file no longer exists, and I just try using st_fts_l2s.ftb instead(But I don't know if it's gonna work).